### PR TITLE
Replace removed np.bool8 alias with np.bool_ for NumPy 2.x

### DIFF
--- a/pipedream_solver/nquality.py
+++ b/pipedream_solver/nquality.py
@@ -101,7 +101,7 @@ class QualityBuilder():
         self._kI = self.hydraulics._kI
         self._K_j = superjunction_params['K'].values.astype(np.float64)
         self._c_j = superjunction_params['c_0'].values.astype(np.float64)
-        self.bc = superjunction_params['bc'].values.astype(np.bool8)
+        self.bc = superjunction_params['bc'].values.astype(np.bool_)
         if junction_params is not None:
             self._K_Ik = junction_params['K'].values.astype(np.float64)
             self._c_Ik = junction_params['c_0'].values.astype(np.float64)

--- a/pipedream_solver/nsuperlink.py
+++ b/pipedream_solver/nsuperlink.py
@@ -1679,7 +1679,7 @@ class nSuperLink(SuperLink):
         _H_dk = H_j[_J_dk]
         # Handle which superlinks to reposition
         if reposition is None:
-            reposition = np.ones(NK, dtype=np.bool8)
+            reposition = np.ones(NK, dtype=np.bool_)
         # Reposition junctions
         numba_reposition_junctions(_x_Ik, _z_inv_Ik, _h_Ik, _dx_ik, _Q_ik, _H_dk,
                                     _b0, _zc, _xc, _m, _elem_pos, _i_1k, _I_1k,


### PR DESCRIPTION
## Problem

`np.bool8` was removed in NumPy 2.0. Two remaining uses cause `AttributeError: module 'numpy' has no attribute 'bool8'` under NumPy >= 2.0:

- `pipedream_solver/nsuperlink.py:1682` — in `reposition_junctions()` (`np.ones(NK, dtype=np.bool8)`)
- `pipedream_solver/nquality.py:104` — in `QualityBuilder` construction (`...astype(np.bool8)`)

Most `np.bool8` usages were already migrated to `np.bool_` (e.g. in `superlink.py`); these two were missed, so they only surface on the `reposition_junctions()` / water-quality code paths.

## Fix

Replace both with `np.bool_`, matching the alias already used elsewhere in the codebase. `np.bool_` is valid in both NumPy 1.x and 2.x, so this is backward compatible.

## Context

Hit while coupling pipedream with ANUGA in an environment that requires NumPy 2.x (NumPy 2.3.4). With these two lines fixed, `SuperLink` construction and `reposition_junctions()` work under NumPy 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)